### PR TITLE
Fix/docs redirect links

### DIFF
--- a/document/step1.en.md
+++ b/document/step1.en.md
@@ -74,4 +74,4 @@ Check if you understand the following concepts.
 
 ### Next
 
-[STEP2: Building local environmentSTEP2: Building local environment](document/step2.en.md)
+[STEP2: Building local environmentSTEP2: Building local environment](step2.en.md)

--- a/document/step1.ja.md
+++ b/document/step1.ja.md
@@ -76,4 +76,4 @@
 ---
 ### Next
 
-[STEP2: 環境構築](document/step2.ja.md)
+[STEP2: 環境構築](step2.ja.md)

--- a/document/step2.en.md
+++ b/document/step2.en.md
@@ -105,4 +105,4 @@ The following resources are useful to dive deeper into building environments and
 
 ### Next
 
-[STEP3: Make a listing API](document/step3.en.md)
+[STEP3: Make a listing API](step3.en.md)

--- a/document/step2.ja.md
+++ b/document/step2.ja.md
@@ -106,4 +106,4 @@ $ go run app/main.go
 ---
 ### Next
 
-[STEP3: 出品APIを作る](document/step3.ja.md)
+[STEP3: 出品APIを作る](step3.ja.md)

--- a/document/step3.en.md
+++ b/document/step3.en.md
@@ -205,4 +205,4 @@ Check if you understand the following concepts.
 
 ### Next
 
-[STEP4: Run the application in a virtual environment](document/step4.en.md)
+[STEP4: Run the application in a virtual environment](step4.en.md)

--- a/document/step3.ja.md
+++ b/document/step3.ja.md
@@ -226,4 +226,4 @@ Image not found: <image path>
 
 ### Next
 
-[STEP4: 仮想環境でアプリを動かす](document/step4.ja.md)
+[STEP4: 仮想環境でアプリを動かす](step4.ja.md)

--- a/document/step4.en.md
+++ b/document/step4.en.md
@@ -122,4 +122,4 @@ Make sure you understand the following concepts
 
 ### Next
 
-[STEP5: Implement a simple Mercari webapp as frontend](document/step5.en.md)
+[STEP5: Implement a simple Mercari webapp as frontend](step5.en.md)

--- a/document/step4.ja.md
+++ b/document/step4.ja.md
@@ -129,4 +129,4 @@ STEP4-5 までで docker image の中は STEP2-2 と同じ状態になってい�
 
 ### Next
 
-[STEP5: Webのフロントエンドを実装する](document/step5.ja.md)
+[STEP5: Webのフロントエンドを実装する](step5.ja.md)

--- a/document/step5.en.md
+++ b/document/step5.en.md
@@ -72,4 +72,4 @@ Current `ItemList` shows one column of items sequentially. Use the following ref
 
 ### Next
 
-[STEP6: Run frontend and API using docker-compose](document/step6.en.md)
+[STEP6: Run frontend and API using docker-compose](step6.en.md)

--- a/document/step5.ja.md
+++ b/document/step5.ja.md
@@ -68,4 +68,4 @@ CSSだけではなく、各コンポーネントでreturnされているHTMLタ�
 
 ### Next
 
-[STEP6: docker-composeでAPIとフロントエンドを動かす](document/step6.ja.md)
+[STEP6: docker-composeでAPIとフロントエンドを動かす](step6.ja.md)

--- a/document/step6.en.md
+++ b/document/step6.en.md
@@ -63,3 +63,9 @@ Run `docker-compose up` and check if the following operates properly
 - [http://localhost:3000/](http://localhost:3000/) displayes the frontend page
 - You can add an new item (Listing)
 - You can view the list of all items (ItemList)
+
+---
+
+### Next
+
+[STEP7: Expand application](step7.en.md)

--- a/document/step6.ja.md
+++ b/document/step6.ja.md
@@ -65,4 +65,4 @@
 
 ### Next
 
-[STEP7: アプリの拡張](document/step7.ja.md)
+[STEP7: アプリの拡張](step7.ja.md)


### PR DESCRIPTION
Hi :wave: just a Build@Mercari '21 trainee dropping by ^^

This PR fixes the documentations' **Next step** redirections links, for both JP & EN. As the following photo depicts, the url **/document** part gets duplicated, so the redirection doesn't work correctly.

![image](https://user-images.githubusercontent.com/37770349/165327801-870a1573-d3c5-44a2-bb2c-3b53fa69d5cb.png)

